### PR TITLE
Add function to list inventory items

### DIFF
--- a/shipbob/models/inventory.py
+++ b/shipbob/models/inventory.py
@@ -1,32 +1,63 @@
 from datetime import datetime
-from typing import List, Optional
+from decimal import Decimal
+from typing import Any, List, Optional
 
 from pydantic import BaseModel
+
+
+class InventoryItemDimensions(BaseModel):
+    weight: Decimal
+    length: Decimal
+    width: Decimal
+    depth: Decimal
+
+
+class FulfillableQuantityByFulfillmentCenter(BaseModel):
+    id: int
+    name: str
+    fulfillable_quantity: int
+    onhand_quantity: int
+    committed_quantity: int
+    awaiting_quantity: int
+    internal_transfer_quantity: int
+
+
+class FulfillableQuantityByLot(BaseModel):
+    lot_number: Optional[int]
+    expiration_date: Optional[datetime]
+    fulfillable_quantity: int
+    onhand_quantity: int
+    committed_quantity: int
+    awaiting_quantity: int
+    internal_transfer_quantity: int
+    fulfillable_quantity_by_fulfillment_center: List[FulfillableQuantityByFulfillmentCenter]
 
 
 class InventoryItem(BaseModel):
     id: int
     name: str
-    quantity: int
-    quantity_committed: int
-    lot: Optional[str]
-    expiration_date: Optional[datetime]
-    serial_numbers: List[str]
-    is_dangerous_goods: bool
+    is_digital: bool
+    is_case_pick: bool
+    is_lot: bool
+    dimensions: InventoryItemDimensions
+    total_fulfillable_quantity: int
+    total_onhand_quantity: int
+    total_committed_quantity: int
+    total_sellable_quantity: int
+    total_awaiting_quantity: int
+    total_exception_quantity: int
+    total_internal_transfer_quantity: int
+    total_backordered_quantity: int
+    is_active: bool
+    fulfillable_quantity_by_fulfillment_center: List[FulfillableQuantityByFulfillmentCenter]
+    fulfillable_quantity_by_lot: List[FulfillableQuantityByLot]
+    packaging_attribute: Optional[Any]
 
 
 class InventoryItemSummary(BaseModel):
     id: int
     name: str
     quantity: int
-
-
-class FullfillableItemByFulfillmentCenter(BaseModel):
-    id: int
-    name: str
-    fulfillable_quantity: int
-    onhand_quantity: int
-    committed_quantity: int
 
 
 __all__ = ["InventoryItem", "InventoryItemSummary"]

--- a/shipbob/models/products.py
+++ b/shipbob/models/products.py
@@ -5,7 +5,15 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from .base import Channel
-from .inventory import FullfillableItemByFulfillmentCenter, InventoryItemSummary
+from .inventory import InventoryItemSummary
+
+
+class FulfillableItemByFulfillmentCenter(BaseModel):
+    id: int
+    name: str
+    fulfillable_quantity: int
+    onhand_quantity: int
+    committed_quantity: int
 
 
 class BaseProductModel(BaseModel):
@@ -34,7 +42,7 @@ class Product(BaseProductModel):
     total_onhand_quantity: int
     total_committed_quantity: int
     fulfillable_inventory_items: List[InventoryItemSummary]
-    fulfillable_quantity_by_fulfillment_center: List[FullfillableItemByFulfillmentCenter]
+    fulfillable_quantity_by_fulfillment_center: List[FulfillableItemByFulfillmentCenter]
 
 
 __all__ = ["Product"]

--- a/shipbob/models/shipping.py
+++ b/shipbob/models/shipping.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel
 
 from .base import Address, BaseMeasurementModel
-from .inventory import InventoryItem
 from .products import BaseProductModel
 
 
@@ -90,9 +89,20 @@ class TrackingDetail(BaseModel):
     scac: Optional[str]
 
 
+class ShippedInventoryItem(BaseModel):
+    id: int
+    name: str
+    quantity: int
+    quantity_committed: int
+    lot: Optional[str]
+    expiration_date: Optional[datetime]
+    serial_numbers: List[str]
+    is_dangerous_goods: bool
+
+
 class ShippedProduct(BaseProductModel):
     name: str
-    inventory_items: List[InventoryItem]
+    inventory_items: List[ShippedInventoryItem]
 
 
 class Carton(CartonBaseModel):
@@ -157,6 +167,7 @@ __all__ = [
     "Recipient",
     "ShipmentStatusDetail",
     "TrackingDetail",
+    "ShippedInventoryItem",
     "ShippedProduct",
     "Carton",
     "ParentCarton",


### PR DESCRIPTION
Client now can also get the list of inventory items.

The `InventoryItem` that was initially provided represented information about the shipped product, so it was renamed to `ShippedInventoryItem` and moved to the `shipping` module.